### PR TITLE
call embedder C++ API directly

### DIFF
--- a/Examples/counter/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/Examples/counter/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,4 @@
 import FlutterMacOS
 import Foundation
 
-
-func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-}
+func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {}

--- a/Examples/counter/swift/runner.swift
+++ b/Examples/counter/swift/runner.swift
@@ -146,8 +146,7 @@ enum Counter {
     )
     let window = FlutterWindow(
       properties: viewProperties,
-      project: dartProject,
-      enableImpeller: true
+      project: dartProject
     )
     guard let window else {
       exit(2)

--- a/Examples/counter/swift/runner.swift
+++ b/Examples/counter/swift/runner.swift
@@ -144,7 +144,11 @@ enum Counter {
       title: "Counter",
       appId: "com.example.counter"
     )
-    let window = FlutterWindow(properties: viewProperties, project: dartProject)
+    let window = FlutterWindow(
+      properties: viewProperties,
+      project: dartProject,
+      enableImpeller: true
+    )
     guard let window else {
       exit(2)
     }

--- a/Sources/CxxFlutterSwift/include/CxxFlutterSwift.h
+++ b/Sources/CxxFlutterSwift/include/CxxFlutterSwift.h
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023-2024 PADL Software Pty Ltd
+// Copyright (c) 2023-2025 PADL Software Pty Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.
@@ -21,11 +21,18 @@
 
 #include <flutter_messenger.h>
 #include <flutter_elinux.h>
+#include <flutter_elinux_engine.h>
+#include <flutter_elinux_state.h>
+#include <flutter_elinux_view.h>
 #include <flutter_plugin_registrar.h>
-// #include <flutter_elinux_state.h>
 #include <flutter_platform_views.h>
 
 #ifdef __cplusplus
+#include <vector>
+#include <string>
+
+using CxxVectorOfString = std::vector<std::string, std::allocator<std::string>>;
+
 extern "C" {
 #endif
 

--- a/Sources/CxxFlutterSwift/include/module.modulemap
+++ b/Sources/CxxFlutterSwift/include/module.modulemap
@@ -1,0 +1,3 @@
+module CxxFlutterSwift {
+    header "CxxFlutterSwift.h"
+}

--- a/Sources/FlutterSwift/Base/StringHelpers.swift
+++ b/Sources/FlutterSwift/Base/StringHelpers.swift
@@ -10,7 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux)
+#if os(Linux) && canImport(Glibc)
+
+@_implementationOnly
+import CxxFlutterSwift
+import CxxStdlib
+
 /// Compute the prefix sum of `seq`.
 func scan<
   S: Sequence, U
@@ -58,6 +63,18 @@ extension String {
   func withWideChars<Result>(_ body: (UnsafePointer<CWideChar>) -> Result) -> Result {
     let u32: [CWideChar] = unicodeScalars.map { CWideChar($0.value)! } + [CWideChar(0)]
     return u32.withUnsafeBufferPointer { body($0.baseAddress!) }
+  }
+}
+
+extension Array where Element == String {
+  var cxxVector: CxxVectorOfString {
+    var tmp = CxxVectorOfString()
+
+    for element in self {
+      tmp.push_back(std.string(element))
+    }
+
+    return tmp
   }
 }
 #endif

--- a/Sources/FlutterSwift/Client/FlutterView.swift
+++ b/Sources/FlutterSwift/Client/FlutterView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023-2024 PADL Software Pty Ltd
+// Copyright (c) 2023-2025 PADL Software Pty Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import CxxFlutterSwift
 let kChannelName = "flutter/platform_views"
 
 public struct FlutterView {
-  let view: FlutterDesktopViewRef
+  let view: flutter.FlutterELinuxView
   var platformViewsPluginRegistrar: FlutterPluginRegistrar?
   var platformViewsHandler: FlutterPlatformViewsPlugin?
   var viewController: FlutterViewController? {
@@ -38,16 +38,20 @@ public struct FlutterView {
     }
   }
 
-  init(_ view: FlutterDesktopViewRef) {
+  init(_ view: flutter.FlutterELinuxView) {
     self.view = view
   }
 
+  init(_ view: FlutterDesktopViewRef) {
+    self.init(unsafeBitCast(view, to: flutter.FlutterELinuxView.self))
+  }
+
   public func dispatchEvent() -> Bool {
-    FlutterDesktopViewDispatchEvent(view)
+    view.DispatchEvent()
   }
 
   public var frameRate: Int32 {
-    FlutterDesktopViewGetFrameRate(view)
+    view.GetFrameRate()
   }
 }
 #endif

--- a/Sources/FlutterSwift/Client/FlutterViewController.swift
+++ b/Sources/FlutterSwift/Client/FlutterViewController.swift
@@ -91,11 +91,16 @@ public final class FlutterViewController {
     }
   }
 
-  public init?(properties viewProperties: ViewProperties, project: DartProject) {
+  public init?(
+    properties viewProperties: ViewProperties,
+    project: DartProject,
+    switches: [String: Any] = [:]
+  ) {
     var cViewProperties = FlutterDesktopViewProperties()
     var controller: FlutterDesktopViewControllerRef?
 
-    guard let engine = FlutterEngine(project: project) else { return nil }
+    guard let engine = FlutterEngine(project: project, switches: switches)
+    else { return nil }
     self.engine = engine
 
     cViewProperties.width = viewProperties.width
@@ -145,7 +150,7 @@ public final class FlutterViewController {
 
   public var view: FlutterView {
     didSet {
-      FlutterDesktopEngineSetView(engine.engine, view.view)
+      engine.setView(view)
     }
   }
 

--- a/Sources/FlutterSwift/Client/FlutterWindow.swift
+++ b/Sources/FlutterSwift/Client/FlutterWindow.swift
@@ -27,11 +27,17 @@ public struct FlutterWindow {
 
   public init?(
     properties viewProperties: FlutterViewController.ViewProperties,
-    project: DartProject
+    project: DartProject,
+    enableImpeller: Bool = false
   ) {
+    var switches = [String: Any]()
+    if enableImpeller {
+      switches["enable-impeller"] = true
+    }
     guard let viewController = FlutterViewController(
       properties: viewProperties,
-      project: project
+      project: project,
+      switches: switches
     ) else {
       return nil
     }


### PR DESCRIPTION
Once swiftlang/swift#77995 is merged (i.e. Swift 6.1 is released), we can use the embedder's C++ API from Swift.