### PR TITLE
Always invoke binary reply callback when message handler throws

### DIFF
--- a/Sources/FlutterSwift/Messenger/FlutterDesktopMessenger.swift
+++ b/Sources/FlutterSwift/Messenger/FlutterDesktopMessenger.swift
@@ -187,12 +187,18 @@ public final class FlutterDesktopMessenger: FlutterBinaryMessenger, @unchecked S
 
         nonisolated(unsafe) let responseHandle = message.response_handle
         let _ = Task(priority: priority) { @Sendable [self, handler, channel, messageData] in
-          let response = try await handler(messageData)
-          try? self.sendResponse(
-            on: channel,
-            handle: responseHandle,
-            response: response
-          )
+          do {
+            let response = try await handler(messageData)
+            try? self.sendResponse(
+              on: channel,
+              handle: responseHandle,
+              response: response
+            )
+          } catch {
+            // Always send a response even on error so the Flutter engine
+            // can release the MallocMapping-owned message buffer (flutter/flutter#159363).
+            try? self.sendResponse(on: channel, handle: responseHandle, response: nil)
+          }
         }
       }
 

--- a/Sources/FlutterSwift/Messenger/FlutterPlatformMessenger.swift
+++ b/Sources/FlutterSwift/Messenger/FlutterPlatformMessenger.swift
@@ -132,8 +132,14 @@ public final class FlutterPlatformMessenger: FlutterBinaryMessenger {
 
       let callback = _SendableBinaryReply(callback: callback)
       let _ = Task { @Sendable [handler, message, callback] in
-        let response = try await handler(message)
-        callback(response)
+        do {
+          let response = try await handler(message)
+          callback(response)
+        } catch {
+          // Always invoke the reply callback even on error so the Flutter engine
+          // can release the MallocMapping-owned message buffer (flutter/flutter#159363).
+          callback(nil)
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- `FlutterPlatformMessenger.setMessageHandler` (Darwin/iOS/Android) and `FlutterDesktopMessenger.setMessageHandler` (Linux/eLinux) both spawn a `Task` to call the user-supplied `FlutterBinaryMessageHandler`. If that handler throws, the task exits without ever calling the reply callback (`FlutterBinaryReply` / `sendResponse`).
- The Flutter engine retains the `MallocMapping`-owned message buffer until the reply callback is invoked. When it is never called, the buffer leaks permanently — one per unacknowledged message.
- This matches the pattern described in flutter/flutter#159363. Observed in practice as unbounded growth on `oca/property_event` and `oca/set_property` platform channels in InfernoUI (PADL/inferno_ui#52): 90 leaks (~3.7 KB) after 22 seconds of normal operation, growing without bound.

## Fix

Wrap the `try await handler(message)` call in a `do/catch` in both messenger implementations and call `callback(nil)` / `sendResponse(..., response: nil)` in the catch block, ensuring the reply is always delivered regardless of handler outcome.

## Test plan

- [ ] Build and run InfernoUI on macOS with an active OCA device
- [ ] Run `leaks <pid>` after 2+ hours of operation; confirm zero leaks attributed to `oca/property_event` or `oca/set_property`
- [ ] Confirm existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)