### PR TITLE
CxxFlutterSwift: explicitly linkedLibrary backend C libs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -344,16 +344,26 @@ let X11Sources = ["elinux_window_x11.cc", "native_window_x11.cc"]
 
 let ExcludedSources: [String]
 let BackendDependencies: [Target.Dependency]
+// Explicit link-library list for the chosen backend. SwiftPM resolves
+// .systemLibrary(pkgConfig:) cflags correctly via pkg-config, but doesn't
+// always propagate the pkg-config --libs through a C++ intermediate target
+// (CxxFlutterSwift) to the final executable. Hardcoding .linkedLibrary on
+// CxxFlutterSwift's linkerSettings ensures the libs show up at link time
+// even when pkg-config-driven propagation doesn't.
+let BackendLinkedLibraries: [String]
 
 switch FlutterELinuxBackend {
 case .drmGbm:
   BackendDependencies = ["CLibInput", "CLibDRM", "LibDRM", "CLibUDev", "CGBM"]
+  BackendLinkedLibraries = ["gbm", "EGL", "GLESv2", "drm", "input", "udev", "xkbcommon"]
   ExcludedSources = WaylandSources + DRMEGLSources
 case .drmEglStream:
   BackendDependencies = [] // TODO:
+  BackendLinkedLibraries = []
   ExcludedSources = WaylandSources + DRMGBMSources
 case .wayland:
   BackendDependencies = ["CWaylandCursor", "CWaylandEGL"]
+  BackendLinkedLibraries = ["wayland-client", "wayland-egl", "wayland-cursor", "EGL", "GLESv2", "xkbcommon"]
   ExcludedSources = DRMCommonSources + DRMGBMSources + DRMEGLSources
 }
 
@@ -432,9 +442,10 @@ targets += [
       // FIXME: include path for swift/bridging.h
       .unsafeFlags(["-pthread", "-std=c++17"] + CxxIncludeFlags),
     ],
-    linkerSettings: [
-      // .unsafeFlags(["-pthread"]),
-    ]
+    linkerSettings:
+      BackendLinkedLibraries.map { .linkedLibrary($0) } + [
+        // .unsafeFlags(["-pthread"]),
+      ]
   ),
   .executableTarget(
     name: "counter",


### PR DESCRIPTION
The .systemLibrary(pkgConfig: ...) targets (CGBM, CEGL, CXKBCommon, CLibDRM, CLibInput, CLibUDev, and the wayland-cursor/wayland-egl pair) provide pkg-config-driven cflags that compile cleanly, but SwiftPM doesn't always propagate their pkg-config --libs through a C++ intermediate target (CxxFlutterSwift) to the final executable link. The symptom, seen on cross-builds where pkg-config otherwise works, is ld.lld: undefined symbol: gbm_create_device / eglChooseConfig / xkb_keymap_mod_get_index / ... even though the headers were found.

Add an explicit .linkedLibrary list on CxxFlutterSwift, keyed off the same FlutterELinuxBackend switch that drives BackendDependencies, so the final executable is guaranteed to pick up the backend's C libs. The .systemLibrary + pkgConfig plumbing is kept as-is for the -I/-D side and for environments where SwiftPM does propagate --libs through.

Verified: FLUTTER_SWIFT_BACKEND=gbm swift build links counter cleanly, and the resulting binary's NEEDED list contains libgbm.so.1, libEGL.so.1, libGLESv2.so.2, libdrm.so.2, libinput.so.10, libudev.so.1, libxkbcommon.so.0.