### PR TITLE
build regression against latest `swift-java`

### DIFF
--- a/Sources/FlutterAndroid/SwiftHeapObjectHolderNativeMethods.swift
+++ b/Sources/FlutterAndroid/SwiftHeapObjectHolderNativeMethods.swift
@@ -49,21 +49,23 @@ extension SwiftHeapObjectHolder: AnyJavaObjectWithCustomClassLoader {
   }
 }
 
-@JavaImplementation("com.padl.FlutterAndroid.SwiftHeapObjectHolder")
-public extension JavaClass<SwiftHeapObjectHolder> {
-  @JavaMethod
-  static func _retainSwiftHeapObject(
-    _ heapObjectInt64Ptr: Int64,
-    environment: JNIEnvironment? = nil
-  ) {
-    _ = SwiftHeapObjectHolder._getUnmanagedSwiftHeapObject(heapObjectInt64Ptr)?.retain()
-  }
+// Use @_cdecl directly rather than @JavaImplementation on JavaClass<T>, since
+// swift-java's @JavaImplementation macro produces malformed expansions for generic
+// class specializations (swiftlang/swift-java#674 regression).
+@_cdecl("Java_com_padl_FlutterAndroid_SwiftHeapObjectHolder__1retainSwiftHeapObject")
+public func Java_com_padl_FlutterAndroid_SwiftHeapObjectHolder__1retainSwiftHeapObject(
+  _ environment: JNIEnvironment?,
+  _ clazz: JavaObject?,
+  _ heapObjectInt64Ptr: Int64
+) {
+  _ = SwiftHeapObjectHolder._getUnmanagedSwiftHeapObject(heapObjectInt64Ptr)?.retain()
+}
 
-  @JavaMethod
-  static func _releaseSwiftHeapObject(
-    _ heapObjectInt64Ptr: Int64,
-    environment: JNIEnvironment? = nil
-  ) {
-    SwiftHeapObjectHolder._getUnmanagedSwiftHeapObject(heapObjectInt64Ptr)?.release()
-  }
+@_cdecl("Java_com_padl_FlutterAndroid_SwiftHeapObjectHolder__1releaseSwiftHeapObject")
+public func Java_com_padl_FlutterAndroid_SwiftHeapObjectHolder__1releaseSwiftHeapObject(
+  _ environment: JNIEnvironment?,
+  _ clazz: JavaObject?,
+  _ heapObjectInt64Ptr: Int64
+) {
+  SwiftHeapObjectHolder._getUnmanagedSwiftHeapObject(heapObjectInt64Ptr)?.release()
 }


### PR DESCRIPTION
## Summary

🏭 **Fabrik — stage: Plan**
*branch: fabrik/issue-133 | commit: 4ad10d6a | main: 4ad10d6a9b65a818004a583194a31d77b86e3369 | 2026-05-07 22:28 UTC*

## Problem

🏭 **Fabrik — stage: Plan**
*branch: fabrik/issue-133 | commit: 4ad10d6a | main: 4ad10d6a9b65a818004a583194a31d77b86e3369 | 2026-05-07 22:28 UTC*

## Approach

(Populated by Implement)

## Verification

Replaced the broken `@JavaImplementation` macro on `extension JavaClass<SwiftHeapObjectHolder>` with two direct `@_cdecl` free functions at the correct JNI-mangled symbol names (`Java_com_padl_FlutterAndroid_SwiftHeapObjectHolder__1retainSwiftHeapObject` and `__1releaseSwiftHeapObject`). The swift-java dependency in `Package.swift` remains on `branch: "main"` — no version pinning. An upstream issue should be filed against `swiftlang/swift-java` reporting the PR #674 regression in `@JavaImplementation` for generic class specializations.

---

Closes #22