### PR TITLE
Darwin: stop bundling Flutter framework; delegate to host Xcode project

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,24 +32,17 @@ func tryGuessSwiftRoot() -> String {
 }
 
 let SwiftRoot = EnvSysRoot ?? tryGuessSwiftRoot()
-var FlutterPlatform: String
+var FlutterPlatform: String = ""
 var FlutterUnsafeLinkerFlags: [String] = []
 
-#if os(macOS) // Note: This is the _build_ platform
-// platformSwiftSettings += []
+// On Darwin (macOS/iOS), Flutter.framework / FlutterMacOS.framework is provided
+// by the consumer Xcode project (via $(FRAMEWORK_SEARCH_PATHS) populated by
+// Flutter's xcode_backend.sh / macos_assemble.sh build phases). FlutterSwift
+// therefore declares no Darwin framework dependency at the package level;
+// `swift build` outside of Xcode will compile the codecs but `canImport` will
+// hide the Messenger.
 
-let FlutterRoot = "/opt/flutter"
-let _FlutterLibPath = "\(FlutterRoot)/bin/cache/artifacts/engine"
-
-FlutterPlatform = "darwin-x64"
-let FlutterFramework = "FlutterMacOS"
-let FlutterLibPath = "\(_FlutterLibPath)/\(FlutterPlatform)"
-FlutterUnsafeLinkerFlags = [
-  "-Xlinker", "-F", "-Xlinker", FlutterLibPath,
-  "-Xlinker", "-rpath", "-Xlinker", FlutterLibPath,
-  "-Xlinker", "-framework", "-Xlinker", FlutterFramework,
-]
-#elseif os(Linux)
+#if os(Linux)
 // FIXME: this is clearly not right
 let FlutterRoot = ".build/artifacts/flutterswift/CFlutterEngine/flutter-engine.artifactbundle"
 #if arch(arm64)
@@ -526,7 +519,6 @@ let package = Package(
       name: "FlutterSwift",
       dependencies: [
         .target(name: "CxxFlutterSwift", condition: .when(platforms: [.linux])),
-        .target(name: "Flutter", condition: .when(platforms: [.iOS])),
         .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
         .product(name: "Atomics", package: "swift-atomics"),
         "AsyncExtensions",
@@ -534,7 +526,7 @@ let package = Package(
       cxxSettings: platformCxxSettings,
       swiftSettings: platformSwiftSettings,
       linkerSettings: [
-        .unsafeFlags(FlutterUnsafeLinkerFlags, .when(platforms: [.macOS, .linux])),
+        .unsafeFlags(FlutterUnsafeLinkerFlags, .when(platforms: [.linux])),
       ]
     ),
     .testTarget(
@@ -545,12 +537,8 @@ let package = Package(
       cxxSettings: platformCxxSettings,
       swiftSettings: platformSwiftSettings,
       linkerSettings: [
-        .unsafeFlags(FlutterUnsafeLinkerFlags, .when(platforms: [.macOS, .linux])),
+        .unsafeFlags(FlutterUnsafeLinkerFlags, .when(platforms: [.linux])),
       ]
-    ),
-    .binaryTarget(
-      name: "Flutter",
-      path: "Flutter.xcframework.zip"
     ),
   ] + targets,
   cLanguageStandard: .c17,

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ The following assumes a reasonable degree of familiarity both with Flutter (spec
 
 On mobile and desktop platforms such as macOS, iOS and Android, the `FlutterPlatformMessenger` class wraps the platform's existing [binary messenger](https://api.flutter.dev/flutter/services/BinaryMessenger-class.html). This is due to the platform binary messenger not being replaceable, as it is used by host platform plugins.
 
-On Darwin platforms (that is, iOS and macOS), you can simply add FlutterSwift as a Swift package dependency from Xcode. On Android, you will need to link FlutterSwift into a Java Native Interface (JNI) library that is bundled with your APK (more of which below).
+On Darwin platforms (that is, iOS and macOS), you can simply add FlutterSwift as a Swift package dependency from Xcode. `Flutter.framework` / `FlutterMacOS.framework` is provided by your Flutter project's own xcconfig (via `xcode_backend.sh` / `macos_assemble.sh`), so FlutterSwift declares no Darwin framework dependency at the package level and ships no bundled Flutter binaries — the same mechanism Flutter's SwiftPM-aware plugins (e.g. `url_launcher_macos`) use. Note that standalone `swift build` on Darwin therefore compiles only the codecs; `FlutterPlatformMessenger` is `#if canImport`'d out unless built inside an Xcode project that wires up Flutter.
+
+On Android, you will need to link FlutterSwift into a Java Native Interface (JNI) library that is bundled with your APK (more of which below).
 
 ### Embedded platforms
 


### PR DESCRIPTION
## Summary

Removes two Darwin-specific assumptions baked into \`Package.swift\` that broke under common configurations:

1. **\`/opt/flutter\` was hardcoded as the macOS Flutter SDK root** — broke any developer whose SDK lived elsewhere, and was useless on Apple Silicon (\`darwin-x64\` artifact name only).
2. **\`Flutter.xcframework.zip\` (~63 MB) was committed in the repo** and wired in as a \`.binaryTarget\` for iOS — pinned to whatever engine revision the zip was built against, bloated git history, and risked conflicting with the \`Flutter.framework\` the host Xcode project already provides.

Both are removed. On Darwin, \`Flutter.framework\` / \`FlutterMacOS.framework\` is now sourced from the host Xcode project's \`\$(FRAMEWORK_SEARCH_PATHS)\`, populated by Flutter's standard \`xcode_backend.sh\` / \`macos_assemble.sh\` build phases — the same mechanism Flutter's SwiftPM-aware plugins (e.g. \`url_launcher_macos\`) rely on. SPM targets compiled within an Xcode build inherit those search paths, so \`import FlutterMacOS\` / \`import Flutter\` continues to resolve in \`FlutterPlatformMessenger.swift\`.

Linux and Android (cross-compiled on macOS) code paths are untouched: the Linux branch still emits its own engine linker flags, and the Android branch still overwrites \`FlutterPlatform\` / \`FlutterUnsafeLinkerFlags\` downstream of the Darwin block.

## Tradeoff

Standalone \`swift build\` on Darwin no longer pulls in the Flutter framework — \`FlutterPlatformMessenger\` is hidden by \`#if canImport(...)\`. This is acceptable because the example apps (and intended downstream consumers) reference FlutterSwift via \`XCLocalSwiftPackageReference\` (path-based), and Xcode always supplies the framework. README updated to call this out.

## Test plan

- [x] macOS: \`swift test\` — 28/28 pass
- [x] macOS counter: \`flutter build macos --debug\` — built
- [x] iOS counter (simulator): \`flutter build ios --debug --no-codesign --simulator\` — built
- [x] Android counter: \`JAVA_HOME=… ./gradlew :app:assembleDebug\` — \`BUILD SUCCESSFUL\`
- [x] \`swift package describe\` with \`FLUTTER_SWIFT_JVM=true\` (Android-on-macOS resolve path)
- [ ] eLinux GBM: \`./build-elinux.sh\` (untouched code, untested locally)
- [ ] eLinux Wayland: \`FLUTTER_SWIFT_BACKEND=wayland ./build-elinux.sh\` (untouched code, untested locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)