### PR TITLE
Fix Darwin build: readers cannot be mutating methods on ParserSpan

### DIFF
--- a/Sources/FlutterSwift/Codecs/Standard/AnyFlutterStandardCodable+Parsing.swift
+++ b/Sources/FlutterSwift/Codecs/Standard/AnyFlutterStandardCodable+Parsing.swift
@@ -52,22 +52,22 @@ extension AnyFlutterStandardCodable: ExpressibleByParsing {
     case .int64:
       self = try .int64(Int64(parsing: &input, endianness: .host))
     case .float64:
-      try input.parseAlignment(to: MemoryLayout<Double>.alignment)
+      try parseAlignment(&input, to: MemoryLayout<Double>.alignment)
       self = try .float64(Double(bitPattern: UInt64(parsing: &input, endianness: .host)))
     case .string:
-      self = try .string(input.parseString())
+      self = try .string(parseString(&input))
     case .uint8Data:
-      self = try .uint8Data(input.parseTypedArray(of: UInt8.self))
+      self = try .uint8Data(parseTypedArray(&input, of: UInt8.self))
     case .int32Data:
-      self = try .int32Data(input.parseTypedArray(of: Int32.self))
+      self = try .int32Data(parseTypedArray(&input, of: Int32.self))
     case .int64Data:
-      self = try .int64Data(input.parseTypedArray(of: Int64.self))
+      self = try .int64Data(parseTypedArray(&input, of: Int64.self))
     case .float32Data:
-      self = try .float32Data(input.parseTypedArray(of: Float.self))
+      self = try .float32Data(parseTypedArray(&input, of: Float.self))
     case .float64Data:
-      self = try .float64Data(input.parseTypedArray(of: Double.self))
+      self = try .float64Data(parseTypedArray(&input, of: Double.self))
     case .list:
-      let count = try input.parseSize()
+      let count = try parseSize(&input)
       var values = [AnyFlutterStandardCodable]()
       values.reserveCapacity(count)
       for _ in 0..<count {
@@ -75,7 +75,7 @@ extension AnyFlutterStandardCodable: ExpressibleByParsing {
       }
       self = .list(values)
     case .map:
-      let count = try input.parseSize()
+      let count = try parseSize(&input)
       var values = [AnyFlutterStandardCodable: AnyFlutterStandardCodable](
         minimumCapacity: count
       )

--- a/Sources/FlutterSwift/Codecs/Standard/Decoder/FlutterStandardDecodingState.swift
+++ b/Sources/FlutterSwift/Codecs/Standard/Decoder/FlutterStandardDecodingState.swift
@@ -51,7 +51,9 @@ final class FlutterStandardDecodingState {
   private let bytes: UnsafeRawBufferPointer
   private var offset: Int
 
-  var isAtEnd: Bool { offset >= bytes.count }
+  var isAtEnd: Bool {
+    offset >= bytes.count
+  }
 
   init(bytes: UnsafeRawBufferPointer) {
     self.bytes = bytes
@@ -82,7 +84,7 @@ final class FlutterStandardDecodingState {
     }
   }
 
-  fileprivate func peekStandardField() throws(FlutterSwiftError) -> FlutterStandardField {
+  private func peekStandardField() throws(FlutterSwiftError) -> FlutterStandardField {
     guard offset < bytes.count else {
       throw FlutterSwiftError.eofTooEarly
     }
@@ -95,20 +97,20 @@ final class FlutterStandardDecodingState {
 
   func assertStandardField(_ assertedFieldType: FlutterStandardField) throws(FlutterSwiftError) {
     try withParser { span throws(ParsingError) in
-      try span.parseAssertedField(assertedFieldType)
+      try parseAssertedField(&span, assertedFieldType)
     }
   }
 
   private func decodeSize() throws(FlutterSwiftError) -> Int {
     try withParser { span throws(ParsingError) in
-      try span.parseSize()
+      try parseSize(&span)
     }
   }
 
   func decodeData() throws(FlutterSwiftError) -> Data {
     try withParser { span throws(ParsingError) in
-      try span.parseAssertedField(.uint8Data)
-      return try span.parseData()
+      try parseAssertedField(&span, .uint8Data)
+      return try parseData(&span)
     }
   }
 
@@ -134,8 +136,8 @@ final class FlutterStandardDecodingState {
     _ type: T.Type
   ) throws(FlutterSwiftError) -> [T] {
     try withParser { span throws(ParsingError) in
-      try span.parseAssertedField(fieldType)
-      return try span.parseTypedArray(of: type)
+      try parseAssertedField(&span, fieldType)
+      return try parseTypedArray(&span, of: type)
     }
   }
 
@@ -173,12 +175,10 @@ final class FlutterStandardDecodingState {
     return values
   }
 
-  private func decodeMap<Key, Value>(
+  private func decodeMap<Key: Hashable & Codable, Value: Codable>(
     _ type: KeyValuePair<Key, Value>.Type,
     codingPath: [CodingKey]
-  ) throws -> [Key: Value] where Key: Hashable & Codable,
-    Value: Codable
-  {
+  ) throws -> [Key: Value] {
     try assertStandardField(.map)
     let count = try decodeSize()
     var values = [Key: Value](minimumCapacity: count)
@@ -206,15 +206,15 @@ final class FlutterStandardDecodingState {
 
   func decode(_ type: String.Type) throws(FlutterSwiftError) -> String {
     try withParser { span throws(ParsingError) in
-      try span.parseAssertedField(.string)
-      return try span.parseString()
+      try parseAssertedField(&span, .string)
+      return try parseString(&span)
     }
   }
 
   func decode(_ type: Double.Type) throws(FlutterSwiftError) -> Double {
     try withParser { span throws(ParsingError) in
-      try span.parseAssertedField(.float64)
-      return try span.parseFloat64()
+      try parseAssertedField(&span, .float64)
+      return try parseFloat64(&span)
     }
   }
 
@@ -248,14 +248,14 @@ final class FlutterStandardDecodingState {
 
   func decode(_ type: Int32.Type) throws(FlutterSwiftError) -> Int32 {
     try withParser { span throws(ParsingError) in
-      try span.parseAssertedField(.int32)
+      try parseAssertedField(&span, .int32)
       return try Int32(parsing: &span, endianness: .host)
     }
   }
 
   func decode(_ type: Int64.Type) throws(FlutterSwiftError) -> Int64 {
     try withParser { span throws(ParsingError) in
-      try span.parseAssertedField(.int64)
+      try parseAssertedField(&span, .int64)
       return try Int64(parsing: &span, endianness: .host)
     }
   }
@@ -291,7 +291,7 @@ final class FlutterStandardDecodingState {
     try UInt64(bitPattern: decode(Int64.self))
   }
 
-  func decode<T>(_ type: T.Type, codingPath: [any CodingKey]) throws -> T where T: Decodable {
+  func decode<T: Decodable>(_ type: T.Type, codingPath: [any CodingKey]) throws -> T {
     try FlutterStandardDecodingState.decode(type, state: self, codingPath: [])
   }
 
@@ -305,11 +305,11 @@ final class FlutterStandardDecodingState {
     }
   }
 
-  static func decode<T>(
+  static func decode<T: Decodable>(
     _ type: T.Type,
     state: FlutterStandardDecodingState,
     codingPath: [any CodingKey]
-  ) throws -> T where T: Decodable {
+  ) throws -> T {
     var count: Int?
     if let type = type as? any FlutterMapRepresentable.Type {
       try state.assertStandardField(.map)

--- a/Sources/FlutterSwift/Codecs/Standard/FlutterStandardReader.swift
+++ b/Sources/FlutterSwift/Codecs/Standard/FlutterStandardReader.swift
@@ -61,106 +61,115 @@ extension FlutterStandardField {
   }
 }
 
-extension ParserSpan {
-  /// Reads a type tag and requires it to be `expected`.
-  mutating func parseAssertedField(
-    _ expected: FlutterStandardField
-  ) throws(ParsingError) {
-    let field = try FlutterStandardField(parsing: &self)
-    guard field == expected else {
-      throw ParsingError(userError: FlutterSwiftError.unexpectedStandardFieldType(field))
-    }
-  }
+// These are free functions rather than methods on `ParserSpan`: the span is
+// ~Escapable, so a `mutating` method on it requires an explicit lifetime
+// dependency (`@_lifetime(&self)`), an underscored attribute behind an
+// experimental feature that only BinaryParsing itself can rely on. An
+// extension declared here is rejected on Darwin with "a mutating method
+// cannot have a ~Escapable 'self'". Taking the span `inout` is how the
+// library's own public parsing surface is shaped too — `UInt8(parsing: &input)`.
 
-  /// Reads the codec's variable-length size prefix.
-  ///
-  /// Sizes below 254 are stored in the prefix byte itself; 254 escapes to a
-  /// `UInt16` and 255 to a `UInt32`, both in host byte order.
-  mutating func parseSize() throws(ParsingError) -> Int {
-    let byte = try UInt8(parsing: &self)
-    switch byte {
-    case 254:
-      return try Int(UInt16(parsing: &self, endianness: .host))
-    case 255:
-      let size = try UInt32(parsing: &self, endianness: .host)
-      guard let size = Int(exactly: size) else {
-        throw ParsingError(userError: FlutterSwiftError.variableSizedTypeTooBig)
-      }
-      return size
-    default:
-      return Int(byte)
-    }
+/// Reads a type tag and requires it to be `expected`.
+func parseAssertedField(
+  _ input: inout ParserSpan,
+  _ expected: FlutterStandardField
+) throws(ParsingError) {
+  let field = try FlutterStandardField(parsing: &input)
+  guard field == expected else {
+    throw ParsingError(userError: FlutterSwiftError.unexpectedStandardFieldType(field))
   }
+}
 
-  /// Consumes the padding that aligns the next read to `alignment`.
-  ///
-  /// Padding is measured from the start of the *message*, not from the bytes
-  /// remaining, which is exactly what `ParserSpan.startPosition` reports —
-  /// it stays absolute within the original region even across slicing.
-  mutating func parseAlignment(
-    to alignment: Int
-  ) throws(ParsingError) {
-    let mod = startPosition % alignment
-    guard mod != 0 else { return }
-    let padding = alignment - mod
-    guard padding <= count else {
-      throw ParsingError(userError: FlutterSwiftError.invalidAlignment)
-    }
-    try seek(toRelativeOffset: padding)
-  }
-
-  /// Reads a float64, including the padding that aligns it.
-  mutating func parseFloat64() throws(ParsingError) -> Double {
-    try parseAlignment(to: MemoryLayout<Double>.alignment)
-    return try Double(bitPattern: UInt64(parsing: &self, endianness: .host))
-  }
-
-  /// Reads a length-prefixed byte blob.
-  mutating func parseData() throws(ParsingError) -> Data {
-    let length = try parseSize()
-    return try Data(parsing: &self, byteCount: length)
-  }
-
-  /// Reads a length-prefixed UTF-8 string.
-  ///
-  /// `String(parsingUTF8:count:)` would repair invalid UTF-8 with U+FFFD; the
-  /// codec treats malformed input as a decode failure, so validate instead.
-  mutating func parseString() throws(ParsingError) -> String {
-    let length = try parseSize()
-    let slice = try sliceSpan(byteCount: length)
-    guard let value = slice.withUnsafeBytes({ String(validating: $0, as: UTF8.self) }) else {
-      let raw = slice.withUnsafeBytes { Data($0) }
-      throw ParsingError(userError: FlutterSwiftError.stringNotDecodable(raw))
-    }
-    return value
-  }
-
-  /// Bulk-reads a typed-data array with a single `memcpy`.
-  ///
-  /// Mirrors `writeTypedArray`: typed data is stored in host byte order, so the
-  /// wire bytes already are the elements' in-memory representation. The
-  /// destination array's storage is freshly allocated and therefore correctly
-  /// aligned, and `copyMemory` tolerates an unaligned source, so this is safe
-  /// wherever the message happens to sit.
-  mutating func parseTypedArray<T: BitwiseCopyable>(
-    of type: T.Type
-  ) throws(ParsingError) -> [T] {
-    let count = try parseSize()
-    try parseAlignment(to: MemoryLayout<T>.stride)
-    let (byteCount, overflow) = count.multipliedReportingOverflow(
-      by: MemoryLayout<T>.stride
-    )
-    guard !overflow else {
+/// Reads the codec's variable-length size prefix.
+///
+/// Sizes below 254 are stored in the prefix byte itself; 254 escapes to a
+/// `UInt16` and 255 to a `UInt32`, both in host byte order.
+func parseSize(_ input: inout ParserSpan) throws(ParsingError) -> Int {
+  let byte = try UInt8(parsing: &input)
+  switch byte {
+  case 254:
+    return try Int(UInt16(parsing: &input, endianness: .host))
+  case 255:
+    let size = try UInt32(parsing: &input, endianness: .host)
+    guard let size = Int(exactly: size) else {
       throw ParsingError(userError: FlutterSwiftError.variableSizedTypeTooBig)
     }
-    let slice = try sliceSpan(byteCount: byteCount)
-    return slice.withUnsafeBytes { source in
-      [T](unsafeUninitializedCapacity: count) { destination, initializedCount in
-        if count > 0 {
-          UnsafeMutableRawBufferPointer(destination).copyMemory(from: source)
-        }
-        initializedCount = count
+    return size
+  default:
+    return Int(byte)
+  }
+}
+
+/// Consumes the padding that aligns the next read to `alignment`.
+///
+/// Padding is measured from the start of the *message*, not from the bytes
+/// remaining, which is exactly what `ParserSpan.startPosition` reports —
+/// it stays absolute within the original region even across slicing.
+func parseAlignment(
+  _ input: inout ParserSpan,
+  to alignment: Int
+) throws(ParsingError) {
+  let mod = input.startPosition % alignment
+  guard mod != 0 else { return }
+  let padding = alignment - mod
+  guard padding <= input.count else {
+    throw ParsingError(userError: FlutterSwiftError.invalidAlignment)
+  }
+  try input.seek(toRelativeOffset: padding)
+}
+
+/// Reads a float64, including the padding that aligns it.
+func parseFloat64(_ input: inout ParserSpan) throws(ParsingError) -> Double {
+  try parseAlignment(&input, to: MemoryLayout<Double>.alignment)
+  return try Double(bitPattern: UInt64(parsing: &input, endianness: .host))
+}
+
+/// Reads a length-prefixed byte blob.
+func parseData(_ input: inout ParserSpan) throws(ParsingError) -> Data {
+  let length = try parseSize(&input)
+  return try Data(parsing: &input, byteCount: length)
+}
+
+/// Reads a length-prefixed UTF-8 string.
+///
+/// `String(parsingUTF8:count:)` would repair invalid UTF-8 with U+FFFD; the
+/// codec treats malformed input as a decode failure, so validate instead.
+func parseString(_ input: inout ParserSpan) throws(ParsingError) -> String {
+  let length = try parseSize(&input)
+  let slice = try input.sliceSpan(byteCount: length)
+  guard let value = slice.withUnsafeBytes({ String(validating: $0, as: UTF8.self) }) else {
+    let raw = slice.withUnsafeBytes { Data($0) }
+    throw ParsingError(userError: FlutterSwiftError.stringNotDecodable(raw))
+  }
+  return value
+}
+
+/// Bulk-reads a typed-data array with a single `memcpy`.
+///
+/// Mirrors `writeTypedArray`: typed data is stored in host byte order, so the
+/// wire bytes already are the elements' in-memory representation. The
+/// destination array's storage is freshly allocated and therefore correctly
+/// aligned, and `copyMemory` tolerates an unaligned source, so this is safe
+/// wherever the message happens to sit.
+func parseTypedArray<T: BitwiseCopyable>(
+  _ input: inout ParserSpan,
+  of type: T.Type
+) throws(ParsingError) -> [T] {
+  let count = try parseSize(&input)
+  try parseAlignment(&input, to: MemoryLayout<T>.stride)
+  let (byteCount, overflow) = count.multipliedReportingOverflow(
+    by: MemoryLayout<T>.stride
+  )
+  guard !overflow else {
+    throw ParsingError(userError: FlutterSwiftError.variableSizedTypeTooBig)
+  }
+  let slice = try input.sliceSpan(byteCount: byteCount)
+  return slice.withUnsafeBytes { source in
+    [T](unsafeUninitializedCapacity: count) { destination, initializedCount in
+      if count > 0 {
+        UnsafeMutableRawBufferPointer(destination).copyMemory(from: source)
       }
+      initializedCount = count
     }
   }
 }


### PR DESCRIPTION
Fixes the Darwin build break introduced by #25.

## The error

```
a mutating method cannot have a ~Escapable 'self'
```

`ParserSpan` is `~Escapable`. Mutating it requires an explicit lifetime dependency on `self`, which BinaryParsing declares for its own span methods — `@_lifetime(copy self)` on `seek`/`sliceSpan`, `@_lifetime(&self)` on `atomically` (`ParserSpan.swift:70,105,217`). `@_lifetime` is underscored and gated behind an experimental feature, so an extension declared outside the library can't portably use it.

Linux with Swift 6.3.2 accepted the extension, which is why CI stayed green; the Darwin toolchain correctly doesn't.

**This is not a swift-binary-parsing issue.** 0.0.2 is the latest tag, and the constraint is the language's rather than the library's — upgrading would not help.

## The fix

Free functions taking the span `inout`:

```swift
func parseSize(_ input: inout ParserSpan) throws(ParsingError) -> Int
func parseAlignment(_ input: inout ParserSpan, to alignment: Int) throws(ParsingError)
```

This is also the shape of the library's own public parsing surface — `UInt8(parsing: &input)`, `Data(parsing: &input, byteCount:)` — so the readers now match their callees instead of wrapping them in a different calling convention.

The writers are unaffected and stay as methods: `FlutterStandardByteStreamWriter` is an ordinary escapable protocol conformed by `Array` and `Data`, where `mutating` is fine — and methods-on-the-sink is what the engine does (`ByteStreamWriter::WriteByte`).

## Risk

Pure calling-convention refactor. No byte-level output changes; the full suite passes unchanged (61 tests), including the exact-wire-byte vectors and the parse/write round trips.

Someone with a Mac should confirm the build before merge — I can only verify on Linux, which is exactly the gap that let this through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8RiN7Vde2eCjfUv1ePdAb
